### PR TITLE
fix: address QE review findings — data correctness, error handling, coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,29 @@ Running `uv pip install -e .` requires hatchling (or another build backend) to b
 Adding `[build-system]` and `[tool.hatch.build.targets.wheel]` sections is needed for editable
 installs to work. Alternatively, `uv sync` with the package as a workspace member handles this
 automatically.
+
+## pydicom DS is a factory function, not a class
+
+`pydicom.valuerep.DS` is a factory function that returns either `DSfloat` or `DSdecimal`
+(depending on `pydicom.config.use_DS_decimal`). `isinstance(x, DS)` always returns False.
+Use `isinstance(x, DSfloat)` or `isinstance(x, (DSfloat, DSdecimal))` for type checks.
+`DSfloat` is a subclass of `float`, so `isinstance(DSfloat("1.0"), float)` is True.
+
+## _decode_person_name return type requires MultiValue not list
+
+The `_encode_person_name` function checks `isinstance(value, MultiValue)` to detect multi-valued
+PN fields. Returning a plain `list` from `_decode_person_name` breaks this check on the next
+serialization. Always return `MultiValue(PersonName, results)` for multiple PN values.
+
+## BulkData handler must be forwarded through SQ recursion
+
+`XmlDataElementConverter.get_element_values()` recurses into SQ items via `_element_to_dataset`.
+The `bulk_data_element_handler` must be explicitly passed to `_element_to_dataset` so that BulkData
+elements inside sequence items can be resolved. Without this, BulkData inside SQ silently returns
+`None` (the result of `empty_value_for_VR`).
+
+## ET.register_namespace is process-global
+
+`ET.register_namespace("", NAMESPACE)` affects every XML serialization in the process for that
+namespace. Moving it from module import time into `dataset_to_xml()` limits the side effect to
+callers that actually serialize — tests that only call `dataset_from_xml` are not affected.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ DICOMweb servers are **required** to support both `application/dicom+json` and `
 pip install pydicom-xml
 ```
 
-Requires Python 3.12+ and pydicom 3.0+.
+Requires Python 3.10+ and pydicom 3.0+.
 
 ## Usage
 

--- a/src/pydicom_xml/__init__.py
+++ b/src/pydicom_xml/__init__.py
@@ -10,6 +10,13 @@ conventions (``Dataset.to_json`` / ``Dataset.from_json``).
 
 from pydicom_xml.xmlrep import (
     NAMESPACE,
+    DicomXmlAtValueHexError,
+    DicomXmlAtValueLengthError,
+    DicomXmlError,
+    DicomXmlParseError,
+    DicomXmlRootError,
+    DicomXmlTagHexError,
+    DicomXmlTagLengthError,
     XmlDataElementConverter,
     data_element_to_xml_element,
     dataset_from_xml,
@@ -22,6 +29,13 @@ from_xml = dataset_from_xml
 
 __all__ = [
     "NAMESPACE",
+    "DicomXmlAtValueHexError",
+    "DicomXmlAtValueLengthError",
+    "DicomXmlError",
+    "DicomXmlParseError",
+    "DicomXmlRootError",
+    "DicomXmlTagHexError",
+    "DicomXmlTagLengthError",
     "XmlDataElementConverter",
     "data_element_to_xml_element",
     "dataset_from_xml",

--- a/src/pydicom_xml/xmlrep.py
+++ b/src/pydicom_xml/xmlrep.py
@@ -142,11 +142,16 @@ class DicomXmlRootError(DicomXmlError):
         self.actual_tag = actual_tag
 
 
-# ---------------------------------------------------------------------------
-# Namespace registration (once at import time)
-# ---------------------------------------------------------------------------
+class DicomXmlParseError(DicomXmlError):
+    """Raised when the XML input cannot be parsed (malformed XML)."""
 
-ET.register_namespace("", NAMESPACE)
+    def __init__(self, detail: str) -> None:
+        """Initialize with the XML parse error detail.
+
+        Args:
+            detail: Human-readable explanation from the XML parser.
+        """
+        super().__init__(f"XML parse error: {detail}")
 
 
 # ---------------------------------------------------------------------------
@@ -220,8 +225,9 @@ class XmlDataElementConverter:
         value_elems = attr.findall(f"{_NS_PREFIX}Value")
 
         if items:
-            # SQ — recurse
-            return Sequence([_element_to_dataset(self.dataset_class, item) for item in items])
+            # SQ — recurse, forwarding the bulk_data_element_handler so BulkData
+            # elements inside sequence items are resolved correctly.
+            return Sequence([_element_to_dataset(self.dataset_class, item, self.bulk_data_element_handler) for item in items])
 
         if pn_elems:
             return _decode_person_name(attr)
@@ -381,7 +387,11 @@ def _encode_binary(
     Args:
         elem: pydicom DataElement with a binary VR.
         parent: XML element to append the encoding to.
-        bulk_data_threshold: Byte threshold above which BulkData URI is used.
+        bulk_data_threshold: Threshold in bytes for switching to BulkData URI.
+            The comparison is ``len(raw_bytes) > (threshold // 4) * 3``, which
+            converts the base64-encoded length threshold to the equivalent raw byte
+            count (base64 expands by 4/3).  This matches the semantics of
+            ``DataElement.to_json_dict()``.
         bulk_data_element_handler: Callable that returns the BulkData URI string.
     """
     raw: bytes = elem.value
@@ -490,14 +500,14 @@ def _parse_pn_group(group_elem: ET.Element) -> str:
     return "^".join(parts)
 
 
-def _decode_person_name(attr_elem: ET.Element) -> PersonName | list[PersonName]:
+def _decode_person_name(attr_elem: ET.Element) -> PersonName | MultiValue[PersonName]:
     """Decode all ``<PersonName>`` children of a DicomAttribute into a PersonName value.
 
     Args:
         attr_elem: A ``<DicomAttribute vr="PN">`` element.
 
     Returns:
-        A single PersonName if only one is present, or a list for multi-valued PN.
+        A single PersonName if only one is present, or a MultiValue for multi-valued PN.
     """
     pn_elems = attr_elem.findall(f"{_NS_PREFIX}PersonName")
     results: list[PersonName] = []
@@ -516,7 +526,7 @@ def _decode_person_name(attr_elem: ET.Element) -> PersonName | list[PersonName]:
 
     if len(results) == 1:
         return results[0]
-    return results
+    return MultiValue(PersonName, results)
 
 
 def _coerce_value(text: str, vr: str) -> Any:
@@ -545,16 +555,22 @@ def _coerce_value(text: str, vr: str) -> Any:
         DicomXmlAtValueLengthError: If AT value text is not exactly 8 characters.
         DicomXmlAtValueHexError: If AT value text contains non-hex characters.
     """
+    from pydicom.dataelem import empty_value_for_VR
     from pydicom.valuerep import DS, IS
 
-    if vr in (INT_VR - {VR.AT}) | {VR.US_SS}:
-        return int(text)
-    if vr in FLOAT_VR:
-        return float(text)
+    if not text or not text.strip():
+        return empty_value_for_VR(vr)
+    # DS and IS must be checked before generic FLOAT_VR/INT_VR because pydicom's
+    # FLOAT_VR includes DS and INT_VR includes IS.  Checking first preserves the
+    # pydicom wrapper type (DS/IS) which carries the original string representation.
     if vr == "DS":
         return DS(text)
     if vr == "IS":
         return IS(text)
+    if vr in (INT_VR - {VR.AT}) | {VR.US_SS}:
+        return int(text)
+    if vr in FLOAT_VR:
+        return float(text)
     if vr == "AT":
         if len(text) != 8:
             raise DicomXmlAtValueLengthError(text)
@@ -586,7 +602,49 @@ def _decode_values(attr_elem: ET.Element, vr: str) -> Any:
     return MultiValue(type(coerced[0]), coerced)
 
 
-def _element_to_dataset(dataset_class: type[Dataset], parent: ET.Element) -> Dataset:
+def _parse_tag_and_vr(attr_elem: ET.Element) -> tuple[BaseTag, str]:
+    """Parse the ``tag`` and ``vr`` attributes from a ``<DicomAttribute>`` element.
+
+    Extracted from ``dataset_from_xml`` and ``_element_to_dataset`` to avoid
+    duplicating the same tag-parsing logic in both functions.
+
+    Args:
+        attr_elem: A ``<DicomAttribute>`` XML element.
+
+    Returns:
+        Tuple of ``(tag, vr)`` where ``vr`` is resolved from the data dictionary
+        when the attribute is absent, and falls back to ``"UN"`` for unknown tags.
+
+    Raises:
+        DicomXmlTagLengthError: If the ``tag`` attribute is not exactly 8 characters.
+        DicomXmlTagHexError: If the ``tag`` attribute contains non-hex characters.
+    """
+    import pydicom.datadict as dd
+
+    tag_str = attr_elem.get("tag", "")
+    if len(tag_str) != 8:
+        raise DicomXmlTagLengthError(tag_str)
+    try:
+        tag = Tag(int(tag_str[:4], 16), int(tag_str[4:], 16))
+    except ValueError as exc:
+        raise DicomXmlTagHexError(tag_str) from exc
+
+    vr: str = attr_elem.get("vr", "")
+    if not vr:
+        try:
+            entry = dd.get_entry(tag)
+            vr = entry[0]
+        except KeyError:
+            vr = "UN"
+
+    return tag, vr
+
+
+def _element_to_dataset(
+    dataset_class: type[Dataset],
+    parent: ET.Element,
+    bulk_data_element_handler: BulkDataHandlerType = None,
+) -> Dataset:
     """Recursively convert ``<DicomAttribute>`` XML children to a pydicom Dataset.
 
     Per PS3.19 A.1, each ``<DicomAttribute>`` has a ``tag`` and ``vr`` attribute.
@@ -595,6 +653,8 @@ def _element_to_dataset(dataset_class: type[Dataset], parent: ET.Element) -> Dat
     Args:
         dataset_class: The Dataset subclass to instantiate for each item.
         parent: A ``<NativeDicomModel>`` or ``<Item>`` XML element.
+        bulk_data_element_handler: Optional handler forwarded to converters so
+            BulkData elements inside sequence items can be resolved.
 
     Returns:
         pydicom Dataset populated from the XML children.
@@ -603,29 +663,11 @@ def _element_to_dataset(dataset_class: type[Dataset], parent: ET.Element) -> Dat
         DicomXmlTagLengthError: If a tag attribute string is not exactly 8 characters.
         DicomXmlTagHexError: If a tag attribute string contains non-hex characters.
     """
-    import pydicom.datadict as dd
-
     ds = dataset_class()
 
     for attr_elem in parent.findall(f"{_NS_PREFIX}DicomAttribute"):
-        tag_str = attr_elem.get("tag", "")
-        if len(tag_str) != 8:
-            raise DicomXmlTagLengthError(tag_str)
-        try:
-            tag = Tag(int(tag_str[:4], 16), int(tag_str[4:], 16))
-        except ValueError as exc:
-            raise DicomXmlTagHexError(tag_str) from exc
-
-        vr: str = attr_elem.get("vr", "")
-        if not vr:
-            # Attempt dictionary lookup; fall back to UN for unknown tags
-            try:
-                entry = dd.get_entry(tag)
-                vr = entry[0]
-            except KeyError:
-                vr = "UN"
-
-        converter = XmlDataElementConverter(dataset_class, attr_elem)
+        tag, vr = _parse_tag_and_vr(attr_elem)
+        converter = XmlDataElementConverter(dataset_class, attr_elem, bulk_data_element_handler)
         value = converter.get_element_values()
         ds.add(DataElement(tag, vr, value))
 
@@ -642,6 +684,7 @@ def data_element_to_xml_element(
     parent: ET.Element,
     bulk_data_threshold: int = 1024,
     bulk_data_element_handler: Callable[[DataElement], str] | None = None,
+    private_creator: str | None = None,
 ) -> ET.Element:
     """Convert a DataElement to an XML ``<DicomAttribute>`` element appended to ``parent``.
 
@@ -660,6 +703,10 @@ def data_element_to_xml_element(
             BulkData URI rather than InlineBinary.  Ignored when no handler is given.
         bulk_data_element_handler: Callable accepting a DataElement and returning the
             ``BulkDataURI`` string.  Mirrors ``DataElement.to_json_dict()`` parameter.
+        private_creator: Optional private creator string.  When provided and the element
+            is a private non-creator element, the ``privateCreator`` attribute is set.
+            Use this when calling the function outside a Dataset context where the creator
+            cannot be looked up automatically.
 
     Returns:
         The newly created ``<DicomAttribute>`` XML element.
@@ -673,6 +720,9 @@ def data_element_to_xml_element(
     kw = dd.keyword_for_tag(data_element.tag)
     if kw:
         attr_elem.set("keyword", kw)
+
+    if private_creator and data_element.tag.is_private and not data_element.tag.is_private_creator:
+        attr_elem.set("privateCreator", private_creator)
 
     if not data_element.is_empty:
         vr = data_element.VR
@@ -718,6 +768,9 @@ def dataset_to_xml(
     Returns:
         UTF-8 encoded XML bytes with XML declaration.
     """
+    # Register namespace here rather than at module import time to limit the
+    # process-global side effect to callers that actually serialise XML.
+    ET.register_namespace("", NAMESPACE)
     root = ET.Element(f"{_NS_PREFIX}NativeDicomModel")
     root.set("{http://www.w3.org/XML/1998/namespace}space", "preserve")
     _dataset_to_xml_element(dataset, root, bulk_data_threshold, bulk_data_element_handler)
@@ -758,6 +811,7 @@ def dataset_from_xml(
         pydicom Dataset populated from the XML.
 
     Raises:
+        DicomXmlParseError: If the input cannot be parsed as XML.
         DicomXmlRootError: If the XML root element is not NativeDicomModel in the
             correct namespace.
         DicomXmlTagLengthError: If any DicomAttribute has a malformed tag attribute.
@@ -770,7 +824,10 @@ def dataset_from_xml(
     else:
         xml_bytes = xml_data
 
-    root = ET.fromstring(xml_bytes.decode("utf-8"))
+    try:
+        root = ET.fromstring(xml_bytes.decode("utf-8"))
+    except ET.ParseError as exc:
+        raise DicomXmlParseError(str(exc)) from exc
 
     if root.tag != f"{_NS_PREFIX}NativeDicomModel":
         raise DicomXmlRootError(root.tag)
@@ -790,24 +847,7 @@ def dataset_from_xml(
     # Use a dataset_class-aware converter for the top-level dataset
     ds = dataset_class()
     for attr_elem in root.findall(f"{_NS_PREFIX}DicomAttribute"):
-        tag_str_raw = attr_elem.get("tag", "")
-        if len(tag_str_raw) != 8:
-            raise DicomXmlTagLengthError(tag_str_raw)
-        try:
-            tag = Tag(int(tag_str_raw[:4], 16), int(tag_str_raw[4:], 16))
-        except ValueError as exc:
-            raise DicomXmlTagHexError(tag_str_raw) from exc
-
-        import pydicom.datadict as dd
-
-        vr: str = attr_elem.get("vr", "")
-        if not vr:
-            try:
-                entry = dd.get_entry(tag)
-                vr = entry[0]
-            except KeyError:
-                vr = "UN"
-
+        tag, vr = _parse_tag_and_vr(attr_elem)
         converter = XmlDataElementConverter(dataset_class, attr_elem, handler)
         value = converter.get_element_values()
         ds.add(DataElement(tag, vr, value))

--- a/tests/test_xmlrep.py
+++ b/tests/test_xmlrep.py
@@ -145,20 +145,34 @@ class TestXmlDataElementConverterValues:
         assert isinstance(result, float)
         assert result == pytest.approx(2.718281828)
 
-    def test_ds_returns_float_value(self) -> None:
-        """Contract: DS Value element returns a float (DS is in FLOAT_VR in pydicom)."""
+    def test_ds_returns_ds_type_preserving_string(self) -> None:
+        """Contract: DS Value element returns pydicom DSfloat (preserves string representation)."""
+        from pydicom.valuerep import DSfloat
+
         attr = _make_dicom_attribute("00180088", "DS", [_make_value_child(1, "1.5")])
         converter = XmlDataElementConverter(Dataset, attr)
         result = converter.get_element_values()
-        # pydicom's FLOAT_VR includes DS, so _coerce_value returns float
+        assert isinstance(result, DSfloat)
         assert float(result) == pytest.approx(1.5)
 
-    def test_is_returns_int_value(self) -> None:
-        """Contract: IS Value element returns an int (IS is in INT_VR in pydicom)."""
+    def test_ds_preserves_string_representation(self) -> None:
+        """Contract: DS with exact decimal text preserves the original string on round-trip."""
+        from pydicom.valuerep import DSfloat
+
+        attr = _make_dicom_attribute("00180088", "DS", [_make_value_child(1, "1.000")])
+        converter = XmlDataElementConverter(Dataset, attr)
+        result = converter.get_element_values()
+        assert isinstance(result, DSfloat)
+        assert str(result) == "1.000"
+
+    def test_is_returns_is_type(self) -> None:
+        """Contract: IS Value element returns pydicom IS (not plain int)."""
+        from pydicom.valuerep import IS
+
         attr = _make_dicom_attribute("00200013", "IS", [_make_value_child(1, "42")])
         converter = XmlDataElementConverter(Dataset, attr)
         result = converter.get_element_values()
-        # pydicom's INT_VR includes IS, so _coerce_value returns int
+        assert isinstance(result, IS)
         assert int(result) == 42
 
     def test_multivalued_lo_returns_multivalue(self) -> None:
@@ -640,3 +654,466 @@ class TestDatasetFromXml:
         result = dataset_from_xml(xml_bytes, bulk_data_uri_handler=resolve)
         assert result[Tag(0x7FE0, 0x0010)].value == payload
         assert calls == [("7FE00010", "OW", "http://example.com/pixel")]
+
+
+# ---------------------------------------------------------------------------
+# Critical fix 1: DS/IS type preservation
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceValueDsIs:
+    def test_ds_round_trip_preserves_string_repr(self) -> None:
+        """Contract: DS "1.000" survives round-trip with exact string representation."""
+        from pydicom.valuerep import DSfloat
+
+        ds = Dataset()
+        # Build a DSfloat with the original string representation
+        ds.add_new(Tag(0x0018, 0x0088), "DS", DSfloat("1.000"))
+        result = dataset_from_xml(dataset_to_xml(ds))
+        val = result[Tag(0x0018, 0x0088)].value
+        assert isinstance(val, DSfloat)
+        assert str(val) == "1.000"
+
+    def test_is_round_trip_returns_is_type(self) -> None:
+        """Contract: IS value returns pydicom IS type (not plain int) after round-trip."""
+        from pydicom.valuerep import IS
+
+        ds = Dataset()
+        ds.add_new(Tag(0x0020, 0x0013), "IS", IS("99"))
+        result = dataset_from_xml(dataset_to_xml(ds))
+        val = result[Tag(0x0020, 0x0013)].value
+        assert isinstance(val, IS)
+        assert int(val) == 99
+
+    def test_ds_returns_dsfloat_not_plain_float(self) -> None:
+        """Contract: _coerce_value for DS returns DSfloat instance, not plain float."""
+        from pydicom.valuerep import DSfloat
+
+        from pydicom_xml.xmlrep import _coerce_value
+
+        result = _coerce_value("3.14", "DS")
+        # DSfloat is a subclass of float, but it carries string representation.
+        # The key check: it must be DSfloat (not just any float).
+        assert isinstance(result, DSfloat)
+
+    def test_is_returns_is_not_int(self) -> None:
+        """Contract: _coerce_value for IS returns IS instance, not plain int."""
+        from pydicom.valuerep import IS
+
+        from pydicom_xml.xmlrep import _coerce_value
+
+        result = _coerce_value("42", "IS")
+        assert isinstance(result, IS)
+
+
+# ---------------------------------------------------------------------------
+# Critical fix 2: Multi-valued PersonName returns MultiValue
+# ---------------------------------------------------------------------------
+
+
+class TestMultiValuedPersonName:
+    def test_multi_pn_decode_returns_multivalue(self) -> None:
+        """Contract: DicomAttribute with two PersonName elements returns MultiValue."""
+        from pydicom.multival import MultiValue
+
+        from pydicom_xml.xmlrep import _decode_person_name
+
+        ns = f"{{{NAMESPACE}}}"
+        attr = ET.Element(f"{ns}DicomAttribute")
+        attr.set("tag", "00100010")
+        attr.set("vr", "PN")
+
+        for idx, name_str in enumerate(["Smith^John", "Doe^Jane"], start=1):
+            pn_elem = ET.SubElement(attr, f"{ns}PersonName")
+            pn_elem.set("number", str(idx))
+            alpha = ET.SubElement(pn_elem, f"{ns}Alphabetic")
+            parts = name_str.split("^")
+            family = ET.SubElement(alpha, f"{ns}FamilyName")
+            family.text = parts[0]
+            given = ET.SubElement(alpha, f"{ns}GivenName")
+            given.text = parts[1]
+
+        result = _decode_person_name(attr)
+        assert isinstance(result, MultiValue)
+        assert len(result) == 2
+
+    def test_multi_pn_round_trip_preserves_both_names(self) -> None:
+        """Contract: two-name PN field survives to_xml/from_xml with both names present."""
+        from pydicom.multival import MultiValue
+        from pydicom.valuerep import PersonName
+
+        ds = Dataset()
+        pn1 = PersonName("Smith^John")
+        pn2 = PersonName("Doe^Jane")
+        ds.add_new(Tag(0x0010, 0x0010), "PN", MultiValue(PersonName, [pn1, pn2]))
+
+        result = dataset_from_xml(dataset_to_xml(ds))
+        val = result[Tag(0x0010, 0x0010)].value
+        assert isinstance(val, MultiValue)
+        assert len(val) == 2
+        assert str(val[0]) == "Smith^John"
+        assert str(val[1]) == "Doe^Jane"
+
+
+# ---------------------------------------------------------------------------
+# Critical fix 3: ET.ParseError raised as DicomXmlParseError
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedXmlRaisesParseError:
+    def test_garbage_bytes_raise_parse_error(self) -> None:
+        """Contract: garbage input to dataset_from_xml raises DicomXmlParseError."""
+        from pydicom_xml.xmlrep import DicomXmlParseError
+
+        with pytest.raises(DicomXmlParseError):
+            dataset_from_xml(b"this is not xml at all <<<")
+
+    def test_truncated_xml_raises_parse_error(self) -> None:
+        """Contract: truncated XML raises DicomXmlParseError, not ET.ParseError."""
+        from pydicom_xml.xmlrep import DicomXmlParseError
+
+        with pytest.raises(DicomXmlParseError):
+            dataset_from_xml(b"<?xml version='1.0'?><NativeDicomModel")
+
+    def test_parse_error_is_subclass_of_dicom_xml_error(self) -> None:
+        """Contract: DicomXmlParseError is a subclass of DicomXmlError."""
+        from pydicom_xml.xmlrep import DicomXmlError, DicomXmlParseError
+
+        assert issubclass(DicomXmlParseError, DicomXmlError)
+
+    def test_parse_error_exported_from_package(self) -> None:
+        """Contract: DicomXmlParseError is importable from pydicom_xml."""
+        from pydicom_xml import DicomXmlParseError
+
+        assert DicomXmlParseError is not None
+
+
+# ---------------------------------------------------------------------------
+# Critical fix 4: empty text in numeric VRs returns empty value
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceValueEmptyText:
+    def test_empty_us_returns_empty_value_not_error(self) -> None:
+        """Contract: _coerce_value("", "US") returns empty value, not ValueError."""
+        from pydicom_xml.xmlrep import _coerce_value
+
+        result = _coerce_value("", "US")
+        # Should not raise — returns empty_value_for_VR("US")
+        assert result is None or result == ""
+
+    def test_whitespace_only_us_returns_empty_value(self) -> None:
+        """Contract: _coerce_value("   ", "US") returns empty value, not ValueError."""
+        from pydicom_xml.xmlrep import _coerce_value
+
+        result = _coerce_value("   ", "US")
+        assert result is None or result == ""
+
+    def test_empty_ds_returns_empty_value(self) -> None:
+        """Contract: _coerce_value("", "DS") returns empty value, not error."""
+        from pydicom_xml.xmlrep import _coerce_value
+
+        result = _coerce_value("", "DS")
+        assert result is None or result == ""
+
+    def test_empty_is_returns_empty_value(self) -> None:
+        """Contract: _coerce_value("", "IS") returns empty value, not error."""
+        from pydicom_xml.xmlrep import _coerce_value
+
+        result = _coerce_value("", "IS")
+        assert result is None or result == ""
+
+
+# ---------------------------------------------------------------------------
+# Fix 5: All exceptions exported from __init__.py
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionExports:
+    def test_all_exceptions_importable_from_package(self) -> None:
+        """Contract: all custom exception classes are importable from pydicom_xml."""
+        import pydicom_xml
+
+        for name in [
+            "DicomXmlError",
+            "DicomXmlAtValueHexError",
+            "DicomXmlAtValueLengthError",
+            "DicomXmlParseError",
+            "DicomXmlRootError",
+            "DicomXmlTagHexError",
+            "DicomXmlTagLengthError",
+        ]:
+            assert hasattr(pydicom_xml, name), f"Missing export: {name}"
+
+    def test_all_exceptions_in_all(self) -> None:
+        """Contract: all custom exception classes appear in pydicom_xml.__all__."""
+        import pydicom_xml
+
+        for name in [
+            "DicomXmlError",
+            "DicomXmlAtValueHexError",
+            "DicomXmlAtValueLengthError",
+            "DicomXmlParseError",
+            "DicomXmlRootError",
+            "DicomXmlTagHexError",
+            "DicomXmlTagLengthError",
+        ]:
+            assert name in pydicom_xml.__all__, f"Missing from __all__: {name}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 6: data_element_to_xml_element private_creator parameter
+# ---------------------------------------------------------------------------
+
+
+class TestDataElementToXmlPrivateCreator:
+    def test_private_creator_set_via_parameter(self) -> None:
+        """Contract: private_creator parameter sets privateCreator attribute on output."""
+        elem = DataElement(Tag(0x0009, 0x1001), "LO", "private value")
+        root = ET.Element(f"{_NS}NativeDicomModel")
+        data_element_to_xml_element(elem, root, private_creator="ACME Corp")
+        attr = root.find(f"{_NS}DicomAttribute")
+        assert attr is not None
+        assert attr.get("privateCreator") == "ACME Corp"
+
+    def test_private_creator_not_set_without_parameter(self) -> None:
+        """Contract: without private_creator parameter the attribute is absent."""
+        elem = DataElement(Tag(0x0009, 0x1001), "LO", "private value")
+        root = ET.Element(f"{_NS}NativeDicomModel")
+        data_element_to_xml_element(elem, root)
+        attr = root.find(f"{_NS}DicomAttribute")
+        assert attr is not None
+        assert attr.get("privateCreator") is None
+
+    def test_private_creator_not_set_for_public_element(self) -> None:
+        """Contract: private_creator parameter is ignored for public elements."""
+        elem = DataElement(Tag(0x0010, 0x0010), "PN", "Smith^John")
+        root = ET.Element(f"{_NS}NativeDicomModel")
+        data_element_to_xml_element(elem, root, private_creator="ACME Corp")
+        attr = root.find(f"{_NS}DicomAttribute")
+        assert attr is not None
+        assert attr.get("privateCreator") is None
+
+    def test_private_creator_not_set_for_creator_element_itself(self) -> None:
+        """Contract: private_creator is not set on the private creator tag itself."""
+        # A private creator element has is_private_creator == True
+        elem = DataElement(Tag(0x0009, 0x0010), "LO", "ACME Corp")
+        root = ET.Element(f"{_NS}NativeDicomModel")
+        data_element_to_xml_element(elem, root, private_creator="ACME Corp")
+        attr = root.find(f"{_NS}DicomAttribute")
+        assert attr is not None
+        assert attr.get("privateCreator") is None
+
+
+# ---------------------------------------------------------------------------
+# Fix 8: _parse_tag_and_vr helper (duplicated logic extracted)
+# ---------------------------------------------------------------------------
+
+
+class TestParseTagAndVr:
+    def test_valid_tag_and_vr(self) -> None:
+        """Contract: _parse_tag_and_vr returns correct tag and vr for valid input."""
+        from pydicom_xml.xmlrep import _parse_tag_and_vr
+
+        attr = _make_dicom_attribute("00100010", "PN")
+        tag, vr = _parse_tag_and_vr(attr)
+        assert tag == Tag(0x0010, 0x0010)
+        assert vr == "PN"
+
+    def test_missing_vr_looks_up_data_dictionary(self) -> None:
+        """Contract: absent vr attribute is resolved from DICOM data dictionary."""
+        from pydicom_xml.xmlrep import _parse_tag_and_vr
+
+        attr = ET.Element(f"{_NS}DicomAttribute")
+        attr.set("tag", "00100010")
+        # no vr attribute
+        tag, vr = _parse_tag_and_vr(attr)
+        assert tag == Tag(0x0010, 0x0010)
+        assert vr != ""  # resolved from data dict (should be "PN")
+
+    def test_unknown_tag_missing_vr_falls_back_to_un(self) -> None:
+        """Contract: private/unknown tag with no vr attribute falls back to UN."""
+        from pydicom_xml.xmlrep import _parse_tag_and_vr
+
+        attr = ET.Element(f"{_NS}DicomAttribute")
+        attr.set("tag", "00091001")  # private, no dict entry
+        # no vr attribute
+        _tag, vr = _parse_tag_and_vr(attr)
+        assert vr == "UN"
+
+    def test_tag_too_short_raises_length_error(self) -> None:
+        """Contract: tag shorter than 8 chars raises DicomXmlTagLengthError."""
+        from pydicom_xml.xmlrep import DicomXmlTagLengthError, _parse_tag_and_vr
+
+        attr = ET.Element(f"{_NS}DicomAttribute")
+        attr.set("tag", "1234")
+        attr.set("vr", "LO")
+        with pytest.raises(DicomXmlTagLengthError):
+            _parse_tag_and_vr(attr)
+
+    def test_tag_non_hex_raises_hex_error(self) -> None:
+        """Contract: tag with non-hex chars raises DicomXmlTagHexError."""
+        from pydicom_xml.xmlrep import DicomXmlTagHexError, _parse_tag_and_vr
+
+        attr = ET.Element(f"{_NS}DicomAttribute")
+        attr.set("tag", "ZZZZYYYY")
+        attr.set("vr", "LO")
+        with pytest.raises(DicomXmlTagHexError):
+            _parse_tag_and_vr(attr)
+
+
+# ---------------------------------------------------------------------------
+# Fix 10-11: Additional VR coverage
+# ---------------------------------------------------------------------------
+
+
+class TestAdditionalVrCoverage:
+    def test_sv_64bit_int_round_trip(self) -> None:
+        """Contract: SV (64-bit signed integer) round-trips correctly."""
+        ds = Dataset()
+        ds.add_new(Tag(0x0018, 0x9728), "SV", -9007199254740992)
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0018, 0x9728)].value == -9007199254740992
+
+    def test_uv_64bit_uint_round_trip(self) -> None:
+        """Contract: UV (64-bit unsigned integer) round-trips correctly."""
+        ds = Dataset()
+        ds.add_new(Tag(0x0018, 0x9729), "UV", 9007199254740992)
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0018, 0x9729)].value == 9007199254740992
+
+    def test_od_binary_vr_round_trip(self) -> None:
+        """Contract: OD binary VR survives round-trip byte-for-byte."""
+        payload = bytes(range(16))
+        ds = Dataset()
+        ds.add_new(Tag(0x0066, 0x0009), "OD", payload)
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0066, 0x0009)].value == payload
+
+    def test_ol_binary_vr_round_trip(self) -> None:
+        """Contract: OL binary VR survives round-trip byte-for-byte."""
+        payload = bytes(range(12))
+        ds = Dataset()
+        ds.add_new(Tag(0x0066, 0x000F), "OL", payload)
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0066, 0x000F)].value == payload
+
+    def test_uc_unlimited_chars_round_trip(self) -> None:
+        """Contract: UC (Unlimited Characters) VR round-trips correctly."""
+        ds = Dataset()
+        ds.add_new(Tag(0x0008, 0x0119), "UC", "Hello World UC")
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0008, 0x0119)].value == "Hello World UC"
+
+    def test_ur_universal_resource_round_trip(self) -> None:
+        """Contract: UR (Universal Resource Identifier) VR round-trips correctly."""
+        ds = Dataset()
+        ds.add_new(Tag(0x0008, 0x1190), "UR", "http://example.com/resource")
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0008, 0x1190)].value == "http://example.com/resource"
+
+    def test_ut_unlimited_text_round_trip(self) -> None:
+        """Contract: UT (Unlimited Text) VR round-trips correctly."""
+        long_text = "A" * 200
+        ds = Dataset()
+        ds.add_new(Tag(0x0042, 0x0013), "UT", long_text)
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0042, 0x0013)].value == long_text
+
+    def test_ae_application_entity_round_trip(self) -> None:
+        """Contract: AE (Application Entity) VR round-trips correctly."""
+        ds = Dataset()
+        ds.add_new(Tag(0x0008, 0x0054), "AE", "MY_SCP")
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0008, 0x0054)].value == "MY_SCP"
+
+    def test_dt_datetime_round_trip(self) -> None:
+        """Contract: DT (DateTime) VR round-trips correctly."""
+        ds = Dataset()
+        ds.add_new(Tag(0x0008, 0x002A), "DT", "20240101120000.000000")
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0008, 0x002A)].value == "20240101120000.000000"
+
+    def test_tm_time_round_trip(self) -> None:
+        """Contract: TM (Time) VR round-trips correctly."""
+        ds = Dataset()
+        ds.add_new(Tag(0x0008, 0x0030), "TM", "120000.000")
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0008, 0x0030)].value == "120000.000"
+
+    def test_lt_long_text_round_trip(self) -> None:
+        """Contract: LT (Long Text) VR round-trips correctly."""
+        ds = Dataset()
+        ds.add_new(Tag(0x0010, 0x21B0), "LT", "Patient additional history text.")
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0010, 0x21B0)].value == "Patient additional history text."
+
+    def test_st_short_text_round_trip(self) -> None:
+        """Contract: ST (Short Text) VR round-trips correctly."""
+        ds = Dataset()
+        ds.add_new(Tag(0x0008, 0x1030), "ST", "Study description text")
+        result = dataset_from_xml(dataset_to_xml(ds))
+        assert result[Tag(0x0008, 0x1030)].value == "Study description text"
+
+
+class TestInlineBinaryEdgeCases:
+    def test_invalid_base64_in_inline_binary(self) -> None:
+        """Contract: invalid base64 in InlineBinary raises an error, not silent failure."""
+        xml = (
+            f'<?xml version="1.0" encoding="utf-8"?>'
+            f'<NativeDicomModel xmlns="{NAMESPACE}">'
+            f'<DicomAttribute tag="7FE00010" vr="OW">'
+            f"<InlineBinary>!!NOT VALID BASE64!!</InlineBinary>"
+            f"</DicomAttribute>"
+            f"</NativeDicomModel>"
+        ).encode()
+        with pytest.raises((ValueError, Exception)):
+            dataset_from_xml(xml)
+
+    def test_missing_vr_attribute_falls_back_to_un(self) -> None:
+        """Contract: DicomAttribute without vr attribute uses UN as fallback for unknown tags."""
+        ns = NAMESPACE
+        # Use a private tag that won't be in the data dictionary
+        xml = (
+            f'<?xml version="1.0" encoding="utf-8"?>'
+            f'<NativeDicomModel xmlns="{ns}">'
+            f'<DicomAttribute tag="00091001">'
+            f'<Value number="1">test</Value>'
+            f"</DicomAttribute>"
+            f"</NativeDicomModel>"
+        ).encode()
+        result = dataset_from_xml(xml)
+        assert Tag(0x0009, 0x1001) in result
+        assert result[Tag(0x0009, 0x1001)].VR == "UN"
+
+    def test_bulk_data_inside_sequence_item(self) -> None:
+        """Contract: BulkData element inside a SQ item is handled correctly."""
+        payload = bytes(range(64)) * 5  # 320 bytes
+
+        def to_uri(de: DataElement) -> str:
+            return "http://example.com/item-bulk"
+
+        item = Dataset()
+        item.add_new(Tag(0x7FE0, 0x0010), "OW", payload)
+        ds = Dataset()
+        from pydicom.sequence import Sequence
+
+        ds.add_new(Tag(0x5200, 0x9230), "SQ", Sequence([item]))
+        xml_bytes = dataset_to_xml(ds, bulk_data_threshold=100, bulk_data_element_handler=to_uri)
+
+        def from_uri(_tag: str, _vr: str, _uri: str) -> bytes:
+            return payload
+
+        result = dataset_from_xml(xml_bytes, bulk_data_uri_handler=from_uri)
+        inner = result[Tag(0x5200, 0x9230)].value[0]
+        assert inner[Tag(0x7FE0, 0x0010)].value == payload
+
+    def test_private_creator_attribute_in_xml_output(self) -> None:
+        """Contract: dataset_to_xml sets privateCreator on private non-creator elements."""
+        ds = Dataset()
+        ds.add_new(Tag(0x0009, 0x0010), "LO", "My Creator")
+        ds.add_new(Tag(0x0009, 0x1001), "LO", "private data")
+        root = ET.fromstring(dataset_to_xml(ds).decode("utf-8"))
+        priv = root.find(f".//{_NS}DicomAttribute[@tag='00091001']")
+        assert priv is not None
+        assert priv.get("privateCreator") == "My Creator"


### PR DESCRIPTION
## Summary

Fixes all findings from QE review issues #3 (critical/high) and #4 (medium).

### Critical fixes (Issue #3 — data correctness)

- **DS/IS dead code**: `_coerce_value()` now checks DS and IS *before* the generic `FLOAT_VR`/`INT_VR` branches. Previously both branches were unreachable dead code because `FLOAT_VR` includes DS and `INT_VR` includes IS. Fix ensures pydicom `DSfloat`/`IS` wrapper types are returned, preserving string representation on round-trip (e.g. `DS("1.000")` → `str()` → `"1.000"`).
- **Multi-valued PN**: `_decode_person_name()` now returns `MultiValue(PersonName, results)` instead of a plain `list`. Plain lists don't pass the `isinstance(value, MultiValue)` check in `_encode_person_name`, which would silently drop extra PN values on the next serialisation.
- **Malformed XML**: `ET.ParseError` from `ET.fromstring()` is now caught and re-raised as the new `DicomXmlParseError` (subclass of `DicomXmlError`). Previously it escaped as a raw `SyntaxError`.
- **Empty numeric text**: `_coerce_value("", "US")` (and similar) now returns `empty_value_for_VR(vr)` instead of raising `ValueError` from `int("")`.
- **Exception exports**: All custom exception classes added to `__init__.py` imports and `__all__`.

### High finding (Issue #3)

Covered by fixes above (ParseError → DicomXmlParseError, empty text guard).

### Medium fixes (Issue #4)

- **`data_element_to_xml_element` private creator**: Added `private_creator: str | None = None` parameter for callers without a Dataset context.
- **`ET.register_namespace` scope**: Moved from module import time into `dataset_to_xml()` to limit the process-global side effect.
- **Duplicated tag-parsing**: Extracted `_parse_tag_and_vr()` helper used by both `dataset_from_xml` and `_element_to_dataset`.
- **README Python version**: Updated to say Python 3.10+ (matches `pyproject.toml`).
- **`bulk_data_threshold` docstring**: Clarified that comparison is against raw bytes: `len(raw) > (threshold // 4) * 3`.

### Bonus bug found by new tests

`_element_to_dataset` was not forwarding `bulk_data_element_handler` to nested SQ item converters. BulkData elements inside sequence items silently returned `None` instead of the resolved value. Fixed by threading the handler through.

## Test plan

- [ ] `uv run pytest` — 116 passed, 0 failed (was 74 before)
- [ ] `uv run ruff check src/ tests/` — 0 violations
- [ ] `uv run ruff format src/ tests/ --check` — no reformatting needed
- [ ] `uv run mypy src/` — no issues

New tests added (42 total):
- DS/IS type preservation (`TestCoerceValueDsIs`)
- Multi-valued PN round-trip (`TestMultiValuedPersonName`)
- Malformed XML → `DicomXmlParseError` (`TestMalformedXmlRaisesParseError`)
- Empty numeric text → empty value (`TestCoerceValueEmptyText`)
- Exception exports from package (`TestExceptionExports`)
- `private_creator` parameter (`TestDataElementToXmlPrivateCreator`)
- `_parse_tag_and_vr` helper (`TestParseTagAndVr`)
- Additional VR types: SV, UV, OD, OL, UC, UR, UT, AE, DT, TM, LT, ST (`TestAdditionalVrCoverage`)
- Edge cases: invalid base64, missing VR attribute, BulkData in SQ item, privateCreator in output (`TestInlineBinaryEdgeCases`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)