### PR TITLE
feat: add multipart/related XML utilities for DICOMWeb

### DIFF
--- a/src/pydicom_xml/__init__.py
+++ b/src/pydicom_xml/__init__.py
@@ -21,6 +21,9 @@ from pydicom_xml.xmlrep import (
     data_element_to_xml_element,
     dataset_from_xml,
     dataset_to_xml,
+    datasets_from_multipart_xml,
+    datasets_to_multipart_xml,
+    extract_boundary,
 )
 
 # Convenience aliases matching pydicom's Dataset method naming
@@ -40,6 +43,9 @@ __all__ = [
     "data_element_to_xml_element",
     "dataset_from_xml",
     "dataset_to_xml",
+    "datasets_from_multipart_xml",
+    "datasets_to_multipart_xml",
+    "extract_boundary",
     "from_xml",
     "to_xml",
 ]

--- a/src/pydicom_xml/xmlrep.py
+++ b/src/pydicom_xml/xmlrep.py
@@ -853,3 +853,132 @@ def dataset_from_xml(
         ds.add(DataElement(tag, vr, value))
 
     return ds
+
+
+# ---------------------------------------------------------------------------
+# Multipart XML utilities for DICOMWeb (PS3.18)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_BOUNDARY = "pydicom-xml-boundary"
+
+
+def datasets_to_multipart_xml(
+    datasets: list[Dataset],
+    boundary: str | None = None,
+    bulk_data_threshold: int = 1024,
+    bulk_data_element_handler: Callable[[DataElement], str] | None = None,
+) -> tuple[bytes, str]:
+    """Serialize multiple Datasets as ``multipart/related`` with XML parts.
+
+    Per PS3.18, DICOMWeb search results (e.g., QIDO-RS) with
+    ``Accept: application/dicom+xml`` return a ``multipart/related``
+    response where each part is a standalone NativeDicomModel XML document.
+
+    Args:
+        datasets: List of pydicom Datasets to serialize.
+        boundary: MIME boundary string.  Auto-generated if not provided.
+        bulk_data_threshold: Passed through to ``dataset_to_xml``.
+        bulk_data_element_handler: Passed through to ``dataset_to_xml``.
+
+    Returns:
+        A tuple of ``(body_bytes, content_type_header)``.
+        The content_type_header includes the boundary and type parameters.
+
+    """
+    if boundary is None:
+        boundary = _DEFAULT_BOUNDARY
+
+    if not datasets:
+        content_type = f'multipart/related; type="application/dicom+xml"; boundary={boundary}'
+        return f"--{boundary}--\r\n".encode(), content_type
+
+    parts: list[bytes] = []
+    for ds in datasets:
+        xml_bytes = dataset_to_xml(
+            ds,
+            bulk_data_threshold=bulk_data_threshold,
+            bulk_data_element_handler=bulk_data_element_handler,
+        )
+        part_header = (f"--{boundary}\r\nContent-Type: application/dicom+xml\r\n\r\n").encode()
+        parts.append(part_header + xml_bytes + b"\r\n")
+
+    body = b"".join(parts) + f"--{boundary}--\r\n".encode()
+    content_type = f'multipart/related; type="application/dicom+xml"; boundary={boundary}'
+    return body, content_type
+
+
+def datasets_from_multipart_xml(
+    body: bytes,
+    boundary: str,
+    dataset_class: type[Dataset] = Dataset,
+    bulk_data_uri_handler: BulkDataHandlerType | Callable[[str], BulkDataType] | None = None,
+) -> list[Dataset]:
+    """Parse a ``multipart/related`` XML response into a list of Datasets.
+
+    Per PS3.18, DICOMWeb search results with ``application/dicom+xml``
+    use ``multipart/related`` framing with one NativeDicomModel per part.
+
+    Args:
+        body: The raw multipart response body bytes.
+        boundary: The MIME boundary string (from the Content-Type header).
+        dataset_class: Dataset class to use for deserialization.
+        bulk_data_uri_handler: Handler for BulkData URI references.
+
+    Returns:
+        List of pydicom Datasets, one per multipart part.
+
+    """
+    boundary_bytes = f"--{boundary}".encode()
+
+    # Split on boundary markers
+    raw_parts = body.split(boundary_bytes)
+
+    datasets_out: list[Dataset] = []
+    for raw_part in raw_parts:
+        stripped = raw_part.strip()
+        # Skip empty parts (before first boundary) and closing marker
+        if not stripped or stripped == b"--" or stripped.startswith(b"--"):
+            continue
+
+        # Split headers from body on double CRLF
+        if b"\r\n\r\n" in stripped:
+            xml_body = stripped.split(b"\r\n\r\n", 1)[1].strip()
+        elif b"\n\n" in stripped:
+            xml_body = stripped.split(b"\n\n", 1)[1].strip()
+        else:
+            xml_body = stripped
+
+        if not xml_body:
+            continue
+
+        result = dataset_from_xml(
+            xml_body,
+            dataset_class=dataset_class,
+            bulk_data_uri_handler=bulk_data_uri_handler,
+        )
+        datasets_out.append(result)
+
+    return datasets_out
+
+
+def extract_boundary(content_type: str) -> str:
+    """Extract the boundary parameter from a multipart Content-Type header.
+
+    Args:
+        content_type: The Content-Type header value,
+            e.g. ``'multipart/related; type="application/dicom+xml"; boundary=my-boundary'``
+
+    Returns:
+        The boundary string.
+
+    Raises:
+        ValueError: If no boundary parameter is found.
+
+    """
+    for param in content_type.split(";"):
+        param = param.strip()
+        if param.startswith("boundary="):
+            value = param[len("boundary=") :]
+            return value.strip('"')
+    msg = f"No boundary parameter in Content-Type: {content_type}"
+    raise ValueError(msg)

--- a/src/pydicom_xml/xmlrep.py
+++ b/src/pydicom_xml/xmlrep.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import base64
 import io
+import uuid
 import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from inspect import signature
@@ -859,7 +860,10 @@ def dataset_from_xml(
 # Multipart XML utilities for DICOMWeb (PS3.18)
 # ---------------------------------------------------------------------------
 
-_DEFAULT_BOUNDARY = "pydicom-xml-boundary"
+
+def _generate_boundary() -> str:
+    """Generate a unique MIME boundary string."""
+    return f"pydicom-xml-{uuid.uuid4().hex}"
 
 
 def datasets_to_multipart_xml(
@@ -886,7 +890,7 @@ def datasets_to_multipart_xml(
 
     """
     if boundary is None:
-        boundary = _DEFAULT_BOUNDARY
+        boundary = _generate_boundary()
 
     if not datasets:
         content_type = f'multipart/related; type="application/dicom+xml"; boundary={boundary}'
@@ -977,8 +981,9 @@ def extract_boundary(content_type: str) -> str:
     """
     for param in content_type.split(";"):
         param = param.strip()
-        if param.startswith("boundary="):
-            value = param[len("boundary=") :]
-            return value.strip('"')
+        if "=" in param:
+            key, _, value = param.partition("=")
+            if key.strip().lower() == "boundary":
+                return value.strip().strip('"')
     msg = f"No boundary parameter in Content-Type: {content_type}"
     raise ValueError(msg)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,0 +1,138 @@
+"""Tests for multipart/related XML serialization utilities (PS3.18)."""
+
+import pytest
+from pydicom.dataset import Dataset
+
+from pydicom_xml import (
+    datasets_from_multipart_xml,
+    datasets_to_multipart_xml,
+    extract_boundary,
+)
+
+
+@pytest.fixture
+def sample_datasets():
+    ds1 = Dataset()
+    ds1.PatientName = "Smith^John"
+    ds1.PatientID = "PAT-001"
+
+    ds2 = Dataset()
+    ds2.PatientName = "Doe^Jane"
+    ds2.PatientID = "PAT-002"
+
+    ds3 = Dataset()
+    ds3.PatientName = "Brown^Bob"
+    ds3.PatientID = "PAT-003"
+
+    return [ds1, ds2, ds3]
+
+
+class TestDatasetsToMultipartXml:
+    def test_single_dataset_produces_one_part(self):
+        ds = Dataset()
+        ds.PatientID = "TEST-001"
+        body, ct = datasets_to_multipart_xml([ds])
+        assert b"TEST-001" in body
+        assert "multipart/related" in ct
+        assert "boundary=" in ct
+
+    def test_multiple_datasets_produces_multiple_parts(self, sample_datasets):
+        body, ct = datasets_to_multipart_xml(sample_datasets)
+        assert b"PAT-001" in body
+        assert b"PAT-002" in body
+        assert b"PAT-003" in body
+        boundary = extract_boundary(ct)
+        parts = body.split(f"--{boundary}".encode())
+        # First part is empty (before first boundary), last is closing "--"
+        xml_parts = [p for p in parts if b"Content-Type" in p]
+        assert len(xml_parts) == 3
+
+    def test_empty_list_produces_closing_boundary(self):
+        body, ct = datasets_to_multipart_xml([])
+        assert "multipart/related" in ct
+        boundary = extract_boundary(ct)
+        assert body == f"--{boundary}--\r\n".encode()
+
+    def test_custom_boundary(self):
+        ds = Dataset()
+        ds.PatientID = "TEST"
+        body, ct = datasets_to_multipart_xml([ds], boundary="my-custom-boundary")
+        assert "boundary=my-custom-boundary" in ct
+        assert b"--my-custom-boundary" in body
+
+    def test_content_type_includes_type_parameter(self):
+        ds = Dataset()
+        ds.PatientID = "TEST"
+        _, ct = datasets_to_multipart_xml([ds])
+        assert 'type="application/dicom+xml"' in ct
+
+    def test_each_part_has_xml_content_type_header(self, sample_datasets):
+        body, _ = datasets_to_multipart_xml(sample_datasets)
+        assert body.count(b"Content-Type: application/dicom+xml") == 3
+
+    def test_each_part_is_valid_dicom_xml(self, sample_datasets):
+        body, ct = datasets_to_multipart_xml(sample_datasets)
+        boundary = extract_boundary(ct)
+        recovered = datasets_from_multipart_xml(body, boundary)
+        assert len(recovered) == 3
+        for ds in recovered:
+            assert isinstance(ds, Dataset)
+
+
+class TestDatasetsFromMultipartXml:
+    def test_round_trip_single(self):
+        ds = Dataset()
+        ds.PatientID = "RT-001"
+        ds.PatientName = "Roundtrip^Test"
+        body, ct = datasets_to_multipart_xml([ds])
+        boundary = extract_boundary(ct)
+        result = datasets_from_multipart_xml(body, boundary)
+        assert len(result) == 1
+        assert result[0].PatientID == "RT-001"
+        assert str(result[0].PatientName) == "Roundtrip^Test"
+
+    def test_round_trip_multiple(self, sample_datasets):
+        body, ct = datasets_to_multipart_xml(sample_datasets)
+        boundary = extract_boundary(ct)
+        result = datasets_from_multipart_xml(body, boundary)
+        assert len(result) == 3
+        ids = {ds.PatientID for ds in result}
+        assert ids == {"PAT-001", "PAT-002", "PAT-003"}
+
+    def test_round_trip_empty(self):
+        body, ct = datasets_to_multipart_xml([])
+        boundary = extract_boundary(ct)
+        result = datasets_from_multipart_xml(body, boundary)
+        assert result == []
+
+    def test_preserves_nested_sequences(self):
+        ds = Dataset()
+        ds.PatientID = "SQ-001"
+        item = Dataset()
+        item.CodeValue = "T-D1100"
+        item.CodingSchemeDesignator = "SRT"
+        ds.AnatomicRegionSequence = [item]
+        body, ct = datasets_to_multipart_xml([ds])
+        boundary = extract_boundary(ct)
+        result = datasets_from_multipart_xml(body, boundary)
+        assert len(result) == 1
+        assert result[0].AnatomicRegionSequence[0].CodeValue == "T-D1100"
+
+
+class TestExtractBoundary:
+    def test_simple_boundary(self):
+        ct = 'multipart/related; type="application/dicom+xml"; boundary=my-boundary'
+        assert extract_boundary(ct) == "my-boundary"
+
+    def test_quoted_boundary(self):
+        ct = 'multipart/related; type="application/dicom+xml"; boundary="quoted-boundary"'
+        assert extract_boundary(ct) == "quoted-boundary"
+
+    def test_boundary_first(self):
+        ct = 'multipart/related; boundary=first-param; type="application/dicom+xml"'
+        assert extract_boundary(ct) == "first-param"
+
+    def test_no_boundary_raises(self):
+        ct = 'multipart/related; type="application/dicom+xml"'
+        with pytest.raises(ValueError, match="No boundary parameter"):
+            extract_boundary(ct)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -132,6 +132,18 @@ class TestExtractBoundary:
         ct = 'multipart/related; boundary=first-param; type="application/dicom+xml"'
         assert extract_boundary(ct) == "first-param"
 
+    def test_case_insensitive(self):
+        ct = 'multipart/related; type="application/dicom+xml"; Boundary=my-boundary'
+        assert extract_boundary(ct) == "my-boundary"
+
+    def test_uppercase(self):
+        ct = "multipart/related; BOUNDARY=my-boundary"
+        assert extract_boundary(ct) == "my-boundary"
+
+    def test_whitespace_around_equals(self):
+        ct = "multipart/related; boundary = my-boundary"
+        assert extract_boundary(ct) == "my-boundary"
+
     def test_no_boundary_raises(self):
         ct = 'multipart/related; type="application/dicom+xml"'
         with pytest.raises(ValueError, match="No boundary parameter"):


### PR DESCRIPTION
## Summary
- `datasets_to_multipart_xml()` — serialize list of Datasets as multipart/related per PS3.18
- `datasets_from_multipart_xml()` — parse multipart/related XML response back to list of Datasets
- `extract_boundary()` — extract boundary parameter from Content-Type header
- All three exported from `pydicom_xml.__init__`

DICOMWeb search results (QIDO-RS, UPS-RS Search) with `Accept: application/dicom+xml` require `multipart/related` framing with one NativeDicomModel document per part. This shared utility enables any DICOMWeb server or client to handle XML list responses correctly.

## Test plan
- [x] 15 new tests in test_multipart.py
- [x] Round-trip: serialize → parse → verify data preserved
- [x] Empty list, single dataset, multiple datasets
- [x] Custom boundary, boundary extraction, nested sequences
- [x] 131 total tests passing
- [x] ruff check + format clean

## Summary by Sourcery

Add utilities for serializing and parsing DICOMWeb multipart/related XML responses and expose them via the public pydicom_xml API.

New Features:
- Provide datasets_to_multipart_xml to encode lists of Datasets as multipart/related application/dicom+xml bodies with appropriate Content-Type headers.
- Provide datasets_from_multipart_xml to parse multipart/related XML responses back into lists of Datasets.
- Provide extract_boundary helper to obtain the MIME boundary parameter from multipart Content-Type headers.

Tests:
- Add multipart XML serialization and parsing test suite covering single, multiple, and empty datasets, custom boundaries, content-type parameters, nested sequences, and boundary extraction edge cases.